### PR TITLE
Add PHP Unserializer tool with print_r() and var_dump() output formats

### DIFF
--- a/src/app/toolRegistry.ts
+++ b/src/app/toolRegistry.ts
@@ -7,6 +7,7 @@ import {
   Clock,
   Code,
   Database,
+  FileCode2,
   FileJson,
   FileText,
   Globe,
@@ -35,6 +36,7 @@ export const ALL_TOOLS = [
   { icon: Code, name: "Code Playground", id: "code-playground", category: "Development Tools" },
   { icon: Terminal, name: "Regex Generator", id: "regex-generator", category: "Development Tools" },
   { icon: Type, name: "JSON to TypeScript", id: "json-typescript", category: "Development Tools" },
+  { icon: FileCode2, name: "PHP Unserializer", id: "php-unserializer", category: "Development Tools" },
   { icon: Hash, name: "Hash Generator", id: "hash-generator", category: "Generators" },
   { icon: Key, name: "UUID Generator", id: "uuid-generator", category: "Generators" },
   { icon: Lock, name: "Password Generator", id: "password-generator", category: "Generators" },
@@ -91,6 +93,10 @@ export const TOOL_COMPONENTS: Record<ToolId, LazyExoticComponent<ComponentType>>
   markdown: lazyNamed(() => import("@/components/tools/MarkdownEditor"), "MarkdownEditor"),
   "url-encoder": lazyNamed(() => import("@/components/tools/UrlEncoder"), "UrlEncoder"),
   "csv-json": lazyNamed(() => import("@/components/tools/CsvToJsonConverter"), "CsvToJsonConverter"),
+  "php-unserializer": lazyNamed(
+    () => import("@/components/tools/PhpUnserializer"),
+    "PhpUnserializer",
+  ),
   timestamp: lazyNamed(
     () => import("@/components/tools/TimestampConverter"),
     "TimestampConverter",

--- a/src/components/tools/PhpUnserializer.tsx
+++ b/src/components/tools/PhpUnserializer.tsx
@@ -97,26 +97,22 @@ export function PhpUnserializer() {
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-2">
           <div className="inline-flex rounded-md border">
-            <button
+            <Button
               onClick={() => setFormat("print_r")}
-              className={`px-3 py-1.5 text-sm font-medium rounded-l-md transition-colors ${
-                format === "print_r"
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-background text-foreground hover:bg-muted"
-              }`}
+              variant={format === "print_r" ? "default" : "ghost"}
+              size="sm"
+              className="rounded-r-none border-r"
             >
               print_r()
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={() => setFormat("var_dump")}
-              className={`px-3 py-1.5 text-sm font-medium rounded-r-md border-l transition-colors ${
-                format === "var_dump"
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-background text-foreground hover:bg-muted"
-              }`}
+              variant={format === "var_dump" ? "default" : "ghost"}
+              size="sm"
+              className="rounded-l-none"
             >
               var_dump()
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/src/components/tools/PhpUnserializer.tsx
+++ b/src/components/tools/PhpUnserializer.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { BookOpen, Copy, Eraser, Play } from "lucide-react";
+import { toast } from "sonner";
+import { ToolFaqSection, type ToolFaqItem } from "@/components/tools/ToolFaq";
+import {
+  phpUnserialize,
+  formatPrintR,
+  formatVarDump,
+} from "@/utils/php-unserialize";
+
+type OutputFormat = "print_r" | "var_dump";
+
+const FAQ_ITEMS: ToolFaqItem[] = [
+  {
+    q: "What is PHP serialize?",
+    a: "PHP serialize() converts a PHP value (array, object, string, etc.) into a storable string representation. It is commonly used to store complex data in databases or session files.",
+  },
+  {
+    q: "What data types are supported?",
+    a: "This tool supports strings, integers, floats, booleans, null, indexed arrays, associative arrays, and objects — all the types produced by PHP's serialize() function.",
+  },
+  {
+    q: "What is the difference between print_r and var_dump?",
+    a: "print_r() displays human-readable information about a value without type details. var_dump() includes type and length information for each value, making it more useful for debugging.",
+  },
+  {
+    q: "Is this tool safe for untrusted data?",
+    a: "Yes. This tool only parses the serialized string format in JavaScript — it does not execute any PHP code. No data is sent to a server.",
+  },
+];
+
+const EXAMPLE_INPUT =
+  'a:2:{i:0;s:12:"Sample array";i:1;a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}}';
+
+export function PhpUnserializer() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [format, setFormat] = useState<OutputFormat>("print_r");
+
+  const unserialize = () => {
+    if (!input.trim()) {
+      toast.error("Please enter a serialized PHP string.");
+      return;
+    }
+
+    try {
+      const parsed = phpUnserialize(input);
+      const formatted =
+        format === "print_r" ? formatPrintR(parsed) : formatVarDump(parsed);
+      setOutput(formatted);
+      toast.success("Unserialized successfully!");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Invalid serialized string";
+      toast.error(message);
+      setOutput("");
+    }
+  };
+
+  const copyToClipboard = () => {
+    if (!output) return;
+    navigator.clipboard.writeText(output);
+    toast.success("Copied to clipboard!");
+  };
+
+  const clear = () => {
+    setInput("");
+    setOutput("");
+  };
+
+  const loadExample = () => {
+    setInput(EXAMPLE_INPUT);
+    setOutput("");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm font-medium">
+            Serialized PHP String
+          </label>
+          <Button onClick={loadExample} variant="ghost" size="sm" className="gap-2">
+            <BookOpen className="w-4 h-4" />
+            Load Example
+          </Button>
+        </div>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder='e.g. a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}'
+          className="w-full h-32 p-3 rounded-md border bg-background text-foreground font-mono text-sm resize-none focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <div className="inline-flex rounded-md border">
+            <button
+              onClick={() => setFormat("print_r")}
+              className={`px-3 py-1.5 text-sm font-medium rounded-l-md transition-colors ${
+                format === "print_r"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-foreground hover:bg-muted"
+              }`}
+            >
+              print_r()
+            </button>
+            <button
+              onClick={() => setFormat("var_dump")}
+              className={`px-3 py-1.5 text-sm font-medium rounded-r-md border-l transition-colors ${
+                format === "var_dump"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-foreground hover:bg-muted"
+              }`}
+            >
+              var_dump()
+            </button>
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <Button onClick={clear} variant="outline" size="sm" className="gap-2">
+            <Eraser className="w-4 h-4" />
+            Clear
+          </Button>
+          <Button onClick={unserialize} size="sm" className="gap-2">
+            <Play className="w-4 h-4" />
+            Unserialize
+          </Button>
+        </div>
+      </div>
+
+      {output && (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="block text-sm font-medium">
+              Output ({format === "print_r" ? "print_r" : "var_dump"})
+            </label>
+            <Button onClick={copyToClipboard} variant="ghost" size="sm">
+              <Copy className="w-4 h-4 mr-2" />
+              Copy
+            </Button>
+          </div>
+          <pre className="w-full p-3 rounded-md border bg-muted text-foreground font-mono text-sm overflow-auto whitespace-pre max-h-96">
+            {output}
+          </pre>
+        </div>
+      )}
+
+      <ToolFaqSection items={FAQ_ITEMS} />
+    </div>
+  );
+}

--- a/src/utils/php-unserialize.ts
+++ b/src/utils/php-unserialize.ts
@@ -1,0 +1,341 @@
+/**
+ * PHP unserialize utilities — parses PHP serialize() output
+ * and formats it as print_r() or var_dump() text.
+ */
+
+/** Discriminated union representing all PHP serializable types. */
+export type PhpValue =
+  | { type: "string"; value: string }
+  | { type: "int"; value: number }
+  | { type: "float"; value: number }
+  | { type: "bool"; value: boolean }
+  | { type: "null" }
+  | { type: "array"; entries: Array<{ key: PhpValue; value: PhpValue }> }
+  | {
+      type: "object";
+      className: string;
+      properties: Array<{ key: PhpValue; value: PhpValue }>;
+    };
+
+class PhpUnserializeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PhpUnserializeError";
+  }
+}
+
+/** Recursive-descent parser for the PHP serialize format. */
+class Parser {
+  private pos = 0;
+
+  constructor(private input: string) {}
+
+  parse(): PhpValue {
+    const value = this.readValue();
+    return value;
+  }
+
+  private readValue(): PhpValue {
+    if (this.pos >= this.input.length) {
+      throw new PhpUnserializeError("Unexpected end of input");
+    }
+
+    const type = this.input[this.pos];
+
+    switch (type) {
+      case "s":
+        return this.readString();
+      case "i":
+        return this.readInt();
+      case "d":
+        return this.readFloat();
+      case "b":
+        return this.readBool();
+      case "N":
+        return this.readNull();
+      case "a":
+        return this.readArray();
+      case "O":
+        return this.readObject();
+      case "r":
+      case "R":
+        return this.readReference();
+      default:
+        throw new PhpUnserializeError(
+          `Unknown type "${type}" at position ${this.pos}`,
+        );
+    }
+  }
+
+  private expect(char: string) {
+    if (this.input[this.pos] !== char) {
+      throw new PhpUnserializeError(
+        `Expected "${char}" at position ${this.pos}, got "${this.input[this.pos]}"`,
+      );
+    }
+    this.pos++;
+  }
+
+  private readUntil(char: string): string {
+    const start = this.pos;
+    while (this.pos < this.input.length && this.input[this.pos] !== char) {
+      this.pos++;
+    }
+    if (this.pos >= this.input.length) {
+      throw new PhpUnserializeError(
+        `Expected "${char}" but reached end of input`,
+      );
+    }
+    return this.input.slice(start, this.pos);
+  }
+
+  private readString(): PhpValue {
+    this.expect("s");
+    this.expect(":");
+    const lenStr = this.readUntil(":");
+    const len = parseInt(lenStr, 10);
+    if (isNaN(len)) {
+      throw new PhpUnserializeError(`Invalid string length: "${lenStr}"`);
+    }
+    this.expect(":");
+    this.expect('"');
+    const value = this.input.slice(this.pos, this.pos + len);
+    this.pos += len;
+    this.expect('"');
+    this.expect(";");
+    return { type: "string", value };
+  }
+
+  private readInt(): PhpValue {
+    this.expect("i");
+    this.expect(":");
+    const numStr = this.readUntil(";");
+    this.expect(";");
+    const value = parseInt(numStr, 10);
+    if (isNaN(value)) {
+      throw new PhpUnserializeError(`Invalid integer value: "${numStr}"`);
+    }
+    return { type: "int", value };
+  }
+
+  private readFloat(): PhpValue {
+    this.expect("d");
+    this.expect(":");
+    const numStr = this.readUntil(";");
+    this.expect(";");
+
+    let value: number;
+    if (numStr === "INF") value = Infinity;
+    else if (numStr === "-INF") value = -Infinity;
+    else if (numStr === "NAN") value = NaN;
+    else {
+      value = parseFloat(numStr);
+      if (isNaN(value)) {
+        throw new PhpUnserializeError(`Invalid float value: "${numStr}"`);
+      }
+    }
+    return { type: "float", value };
+  }
+
+  private readBool(): PhpValue {
+    this.expect("b");
+    this.expect(":");
+    const val = this.readUntil(";");
+    this.expect(";");
+    if (val !== "0" && val !== "1") {
+      throw new PhpUnserializeError(`Invalid boolean value: "${val}"`);
+    }
+    return { type: "bool", value: val === "1" };
+  }
+
+  private readNull(): PhpValue {
+    this.expect("N");
+    this.expect(";");
+    return { type: "null" };
+  }
+
+  private readArray(): PhpValue {
+    this.expect("a");
+    this.expect(":");
+    const countStr = this.readUntil(":");
+    const count = parseInt(countStr, 10);
+    if (isNaN(count)) {
+      throw new PhpUnserializeError(`Invalid array count: "${countStr}"`);
+    }
+    this.expect(":");
+    this.expect("{");
+
+    const entries: Array<{ key: PhpValue; value: PhpValue }> = [];
+    for (let i = 0; i < count; i++) {
+      const key = this.readValue();
+      const value = this.readValue();
+      entries.push({ key, value });
+    }
+
+    this.expect("}");
+    return { type: "array", entries };
+  }
+
+  private readObject(): PhpValue {
+    this.expect("O");
+    this.expect(":");
+    const classNameLenStr = this.readUntil(":");
+    const classNameLen = parseInt(classNameLenStr, 10);
+    if (isNaN(classNameLen)) {
+      throw new PhpUnserializeError(
+        `Invalid class name length: "${classNameLenStr}"`,
+      );
+    }
+    this.expect(":");
+    this.expect('"');
+    const className = this.input.slice(this.pos, this.pos + classNameLen);
+    this.pos += classNameLen;
+    this.expect('"');
+    this.expect(":");
+    const countStr = this.readUntil(":");
+    const count = parseInt(countStr, 10);
+    if (isNaN(count)) {
+      throw new PhpUnserializeError(
+        `Invalid object property count: "${countStr}"`,
+      );
+    }
+    this.expect(":");
+    this.expect("{");
+
+    const properties: Array<{ key: PhpValue; value: PhpValue }> = [];
+    for (let i = 0; i < count; i++) {
+      const key = this.readValue();
+      const value = this.readValue();
+      properties.push({ key, value });
+    }
+
+    this.expect("}");
+    return { type: "object", className, properties };
+  }
+
+  private readReference(): PhpValue {
+    this.pos++; // skip 'r' or 'R'
+    this.expect(":");
+    const refStr = this.readUntil(";");
+    this.expect(";");
+    return { type: "int", value: parseInt(refStr, 10) };
+  }
+}
+
+/**
+ * Parses a PHP serialize() string into an intermediate PhpValue tree.
+ * @throws PhpUnserializeError on empty or malformed input
+ */
+export function phpUnserialize(input: string): PhpValue {
+  if (!input || input.trim() === "") {
+    throw new PhpUnserializeError("Please enter a serialized PHP string.");
+  }
+  const parser = new Parser(input.trim());
+  return parser.parse();
+}
+
+/** Returns true if the input is a valid PHP serialized string. */
+export function isValidSerialized(input: string): boolean {
+  try {
+    phpUnserialize(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function keyToString(key: PhpValue): string {
+  if (key.type === "int") return String(key.value);
+  if (key.type === "string") return key.value;
+  return String((key as { value?: unknown }).value ?? "");
+}
+
+/** Formats a PhpValue tree as PHP print_r() output. */
+export function formatPrintR(value: PhpValue, indent: number = 0): string {
+  const pad = " ".repeat(indent * 4);
+  const innerPad = " ".repeat((indent + 1) * 4);
+
+  switch (value.type) {
+    case "string":
+      return value.value;
+    case "int":
+    case "float":
+      return String(value.value);
+    case "bool":
+      return value.value ? "1" : "";
+    case "null":
+      return "";
+    case "array": {
+      if (value.entries.length === 0) {
+        return `Array\n${pad}(\n${pad})`;
+      }
+      let result = `Array\n${pad}(\n`;
+      for (const entry of value.entries) {
+        const k = keyToString(entry.key);
+        const v = formatPrintR(entry.value, indent + 2);
+        if (entry.value.type === "array" || entry.value.type === "object") {
+          result += `${innerPad}[${k}] => ${v}\n\n`;
+        } else {
+          result += `${innerPad}[${k}] => ${v}\n`;
+        }
+      }
+      result += `${pad})`;
+      return result;
+    }
+    case "object": {
+      let result = `${value.className} Object\n${pad}(\n`;
+      for (const prop of value.properties) {
+        const k = keyToString(prop.key);
+        const v = formatPrintR(prop.value, indent + 2);
+        if (prop.value.type === "array" || prop.value.type === "object") {
+          result += `${innerPad}[${k}] => ${v}\n\n`;
+        } else {
+          result += `${innerPad}[${k}] => ${v}\n`;
+        }
+      }
+      result += `${pad})`;
+      return result;
+    }
+  }
+}
+
+/** Formats a PhpValue tree as PHP var_dump() output. */
+export function formatVarDump(value: PhpValue, indent: number = 0): string {
+  const pad = " ".repeat(indent * 2);
+  const innerPad = " ".repeat((indent + 1) * 2);
+
+  switch (value.type) {
+    case "string":
+      return `${pad}string(${value.value.length}) "${value.value}"`;
+    case "int":
+      return `${pad}int(${value.value})`;
+    case "float":
+      return `${pad}float(${value.value})`;
+    case "bool":
+      return `${pad}bool(${value.value ? "true" : "false"})`;
+    case "null":
+      return `${pad}NULL`;
+    case "array": {
+      let result = `${pad}array(${value.entries.length}) {\n`;
+      for (const entry of value.entries) {
+        const k = keyToString(entry.key);
+        const keyBracket =
+          entry.key.type === "int" ? `[${k}]` : `["${k}"]`;
+        result += `${innerPad}${keyBracket}=>\n`;
+        result += formatVarDump(entry.value, indent + 1) + "\n";
+      }
+      result += `${pad}}`;
+      return result;
+    }
+    case "object": {
+      let result = `${pad}object(${value.className})#1 (${value.properties.length}) {\n`;
+      for (const prop of value.properties) {
+        const k = keyToString(prop.key);
+        result += `${innerPad}["${k}"]=>\n`;
+        result += formatVarDump(prop.value, indent + 1) + "\n";
+      }
+      result += `${pad}}`;
+      return result;
+    }
+  }
+}

--- a/src/utils/php-unserialize.ts
+++ b/src/utils/php-unserialize.ts
@@ -27,11 +27,18 @@ class PhpUnserializeError extends Error {
 /** Recursive-descent parser for the PHP serialize format. */
 class Parser {
   private pos = 0;
+  private readonly parsedValues: PhpValue[] = [];
+  private readonly utf8Encoder = new TextEncoder();
 
   constructor(private input: string) {}
 
   parse(): PhpValue {
     const value = this.readValue();
+    if (this.pos !== this.input.length) {
+      throw new PhpUnserializeError(
+        `Unexpected trailing characters at position ${this.pos}`,
+      );
+    }
     return value;
   }
 
@@ -89,7 +96,7 @@ class Parser {
     return this.input.slice(start, this.pos);
   }
 
-  private readString(): PhpValue {
+  private readString(registerValue: boolean = true): PhpValue {
     this.expect("s");
     this.expect(":");
     const lenStr = this.readUntil(":");
@@ -99,14 +106,17 @@ class Parser {
     }
     this.expect(":");
     this.expect('"');
-    const value = this.input.slice(this.pos, this.pos + len);
-    this.pos += len;
+    const value = this.readUtf8ByteLengthString(len);
     this.expect('"');
     this.expect(";");
-    return { type: "string", value };
+    const parsed: PhpValue = { type: "string", value };
+    if (registerValue) {
+      this.parsedValues.push(parsed);
+    }
+    return parsed;
   }
 
-  private readInt(): PhpValue {
+  private readInt(registerValue: boolean = true): PhpValue {
     this.expect("i");
     this.expect(":");
     const numStr = this.readUntil(";");
@@ -115,7 +125,11 @@ class Parser {
     if (isNaN(value)) {
       throw new PhpUnserializeError(`Invalid integer value: "${numStr}"`);
     }
-    return { type: "int", value };
+    const parsed: PhpValue = { type: "int", value };
+    if (registerValue) {
+      this.parsedValues.push(parsed);
+    }
+    return parsed;
   }
 
   private readFloat(): PhpValue {
@@ -134,7 +148,9 @@ class Parser {
         throw new PhpUnserializeError(`Invalid float value: "${numStr}"`);
       }
     }
-    return { type: "float", value };
+    const parsed: PhpValue = { type: "float", value };
+    this.parsedValues.push(parsed);
+    return parsed;
   }
 
   private readBool(): PhpValue {
@@ -145,13 +161,17 @@ class Parser {
     if (val !== "0" && val !== "1") {
       throw new PhpUnserializeError(`Invalid boolean value: "${val}"`);
     }
-    return { type: "bool", value: val === "1" };
+    const parsed: PhpValue = { type: "bool", value: val === "1" };
+    this.parsedValues.push(parsed);
+    return parsed;
   }
 
   private readNull(): PhpValue {
     this.expect("N");
     this.expect(";");
-    return { type: "null" };
+    const parsed: PhpValue = { type: "null" };
+    this.parsedValues.push(parsed);
+    return parsed;
   }
 
   private readArray(): PhpValue {
@@ -165,15 +185,22 @@ class Parser {
     this.expect(":");
     this.expect("{");
 
+    const parsed: { type: "array"; entries: Array<{ key: PhpValue; value: PhpValue }> } = {
+      type: "array",
+      entries: [],
+    };
+    this.parsedValues.push(parsed);
+
     const entries: Array<{ key: PhpValue; value: PhpValue }> = [];
     for (let i = 0; i < count; i++) {
-      const key = this.readValue();
+      const key = this.readArrayKey();
       const value = this.readValue();
       entries.push({ key, value });
     }
 
     this.expect("}");
-    return { type: "array", entries };
+    parsed.entries = entries;
+    return parsed;
   }
 
   private readObject(): PhpValue {
@@ -202,15 +229,27 @@ class Parser {
     this.expect(":");
     this.expect("{");
 
+    const parsed: {
+      type: "object";
+      className: string;
+      properties: Array<{ key: PhpValue; value: PhpValue }>;
+    } = {
+      type: "object",
+      className,
+      properties: [],
+    };
+    this.parsedValues.push(parsed);
+
     const properties: Array<{ key: PhpValue; value: PhpValue }> = [];
     for (let i = 0; i < count; i++) {
-      const key = this.readValue();
+      const key = this.readObjectKey();
       const value = this.readValue();
       properties.push({ key, value });
     }
 
     this.expect("}");
-    return { type: "object", className, properties };
+    parsed.properties = properties;
+    return parsed;
   }
 
   private readReference(): PhpValue {
@@ -218,7 +257,74 @@ class Parser {
     this.expect(":");
     const refStr = this.readUntil(";");
     this.expect(";");
-    return { type: "int", value: parseInt(refStr, 10) };
+    const refIndex = parseInt(refStr, 10);
+    if (isNaN(refIndex) || refIndex < 1) {
+      throw new PhpUnserializeError(`Invalid reference index: "${refStr}"`);
+    }
+
+    const referencedValue = this.parsedValues[refIndex - 1];
+    if (!referencedValue) {
+      throw new PhpUnserializeError(
+        `Reference index ${refIndex} does not exist`,
+      );
+    }
+
+    return referencedValue;
+  }
+
+  private readUtf8ByteLengthString(byteLength: number): string {
+    const start = this.pos;
+    let consumedBytes = 0;
+
+    while (consumedBytes < byteLength) {
+      if (this.pos >= this.input.length) {
+        throw new PhpUnserializeError(
+          "Unexpected end of input while reading string bytes",
+        );
+      }
+
+      const codePoint = this.input.codePointAt(this.pos);
+      if (codePoint === undefined) {
+        throw new PhpUnserializeError("Invalid string code point");
+      }
+
+      const char = String.fromCodePoint(codePoint);
+      const charByteLength = this.utf8Encoder.encode(char).length;
+      consumedBytes += charByteLength;
+      this.pos += char.length;
+    }
+
+    if (consumedBytes !== byteLength) {
+      throw new PhpUnserializeError(
+        `String byte length mismatch. Expected ${byteLength}, got ${consumedBytes}`,
+      );
+    }
+
+    return this.input.slice(start, this.pos);
+  }
+
+  private readArrayKey(): PhpValue {
+    const keyType = this.input[this.pos];
+    switch (keyType) {
+      case "i":
+        return this.readInt(false);
+      case "s":
+        return this.readString(false);
+      default:
+        throw new PhpUnserializeError(
+          `Invalid array key type "${keyType}" at position ${this.pos}`,
+        );
+    }
+  }
+
+  private readObjectKey(): PhpValue {
+    const keyType = this.input[this.pos];
+    if (keyType !== "s") {
+      throw new PhpUnserializeError(
+        `Invalid object property key type "${keyType}" at position ${this.pos}`,
+      );
+    }
+    return this.readString(false);
   }
 }
 
@@ -245,9 +351,24 @@ export function isValidSerialized(input: string): boolean {
 }
 
 function keyToString(key: PhpValue): string {
-  if (key.type === "int") return String(key.value);
-  if (key.type === "string") return key.value;
-  return String((key as { value?: unknown }).value ?? "");
+  switch (key.type) {
+    case "int":
+      return String(key.value);
+    case "string":
+      return key.value;
+    case "bool":
+      return key.value ? "1" : "0";
+    case "null":
+      return "";
+    case "float":
+      return String(Math.trunc(key.value));
+    default:
+      return "";
+  }
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
 }
 
 /** Formats a PhpValue tree as PHP print_r() output. */
@@ -273,28 +394,20 @@ export function formatPrintR(value: PhpValue, indent: number = 0): string {
       for (const entry of value.entries) {
         const k = keyToString(entry.key);
         const v = formatPrintR(entry.value, indent + 2);
-        if (entry.value.type === "array" || entry.value.type === "object") {
-          result += `${innerPad}[${k}] => ${v}\n\n`;
-        } else {
-          result += `${innerPad}[${k}] => ${v}\n`;
-        }
+        result += `${innerPad}[${k}] => ${v}\n`;
       }
       result += `${pad})`;
-      return result;
+      return indent > 0 ? `${result}\n` : result;
     }
     case "object": {
       let result = `${value.className} Object\n${pad}(\n`;
       for (const prop of value.properties) {
         const k = keyToString(prop.key);
         const v = formatPrintR(prop.value, indent + 2);
-        if (prop.value.type === "array" || prop.value.type === "object") {
-          result += `${innerPad}[${k}] => ${v}\n\n`;
-        } else {
-          result += `${innerPad}[${k}] => ${v}\n`;
-        }
+        result += `${innerPad}[${k}] => ${v}\n`;
       }
       result += `${pad})`;
-      return result;
+      return indent > 0 ? `${result}\n` : result;
     }
   }
 }
@@ -306,7 +419,7 @@ export function formatVarDump(value: PhpValue, indent: number = 0): string {
 
   switch (value.type) {
     case "string":
-      return `${pad}string(${value.value.length}) "${value.value}"`;
+      return `${pad}string(${utf8ByteLength(value.value)}) "${value.value}"`;
     case "int":
       return `${pad}int(${value.value})`;
     case "float":

--- a/tests/tools/php-unserializer.test.ts
+++ b/tests/tools/php-unserializer.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from "vitest";
+import {
+  phpUnserialize,
+  formatPrintR,
+  formatVarDump,
+  isValidSerialized,
+} from "@/utils/php-unserialize";
+
+describe("PHP Unserialize Utils", () => {
+  describe("phpUnserialize", () => {
+    it("should parse a simple string", () => {
+      const result = phpUnserialize('s:5:"hello";');
+      expect(result).toEqual({ type: "string", value: "hello" });
+    });
+
+    it("should parse an empty string", () => {
+      const result = phpUnserialize('s:0:"";');
+      expect(result).toEqual({ type: "string", value: "" });
+    });
+
+    it("should parse an integer", () => {
+      const result = phpUnserialize("i:42;");
+      expect(result).toEqual({ type: "int", value: 42 });
+    });
+
+    it("should parse a negative integer", () => {
+      const result = phpUnserialize("i:-7;");
+      expect(result).toEqual({ type: "int", value: -7 });
+    });
+
+    it("should parse zero integer", () => {
+      const result = phpUnserialize("i:0;");
+      expect(result).toEqual({ type: "int", value: 0 });
+    });
+
+    it("should parse a float", () => {
+      const result = phpUnserialize("d:3.14;");
+      expect(result).toEqual({ type: "float", value: 3.14 });
+    });
+
+    it("should parse a negative float", () => {
+      const result = phpUnserialize("d:-2.5;");
+      expect(result).toEqual({ type: "float", value: -2.5 });
+    });
+
+    it("should parse boolean true", () => {
+      const result = phpUnserialize("b:1;");
+      expect(result).toEqual({ type: "bool", value: true });
+    });
+
+    it("should parse boolean false", () => {
+      const result = phpUnserialize("b:0;");
+      expect(result).toEqual({ type: "bool", value: false });
+    });
+
+    it("should parse null", () => {
+      const result = phpUnserialize("N;");
+      expect(result).toEqual({ type: "null" });
+    });
+
+    it("should parse an indexed array", () => {
+      const result = phpUnserialize(
+        'a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}',
+      );
+      expect(result).toEqual({
+        type: "array",
+        entries: [
+          {
+            key: { type: "int", value: 0 },
+            value: { type: "string", value: "Apple" },
+          },
+          {
+            key: { type: "int", value: 1 },
+            value: { type: "string", value: "Orange" },
+          },
+        ],
+      });
+    });
+
+    it("should parse an associative array", () => {
+      const result = phpUnserialize(
+        'a:2:{s:4:"name";s:5:"Alice";s:3:"age";i:30;}',
+      );
+      expect(result).toEqual({
+        type: "array",
+        entries: [
+          {
+            key: { type: "string", value: "name" },
+            value: { type: "string", value: "Alice" },
+          },
+          {
+            key: { type: "string", value: "age" },
+            value: { type: "int", value: 30 },
+          },
+        ],
+      });
+    });
+
+    it("should parse a nested array (user example)", () => {
+      const input =
+        'a:2:{i:0;s:12:"Sample array";i:1;a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}}';
+      const result = phpUnserialize(input);
+      expect(result).toEqual({
+        type: "array",
+        entries: [
+          {
+            key: { type: "int", value: 0 },
+            value: { type: "string", value: "Sample array" },
+          },
+          {
+            key: { type: "int", value: 1 },
+            value: {
+              type: "array",
+              entries: [
+                {
+                  key: { type: "int", value: 0 },
+                  value: { type: "string", value: "Apple" },
+                },
+                {
+                  key: { type: "int", value: 1 },
+                  value: { type: "string", value: "Orange" },
+                },
+              ],
+            },
+          },
+        ],
+      });
+    });
+
+    it("should parse an empty array", () => {
+      const result = phpUnserialize("a:0:{}");
+      expect(result).toEqual({ type: "array", entries: [] });
+    });
+
+    it("should parse an object", () => {
+      const result = phpUnserialize(
+        'O:8:"stdClass":1:{s:4:"name";s:5:"Alice";}',
+      );
+      expect(result).toEqual({
+        type: "object",
+        className: "stdClass",
+        properties: [
+          {
+            key: { type: "string", value: "name" },
+            value: { type: "string", value: "Alice" },
+          },
+        ],
+      });
+    });
+
+    it("should throw error for empty input", () => {
+      expect(() => phpUnserialize("")).toThrow(
+        "Please enter a serialized PHP string.",
+      );
+      expect(() => phpUnserialize("   ")).toThrow(
+        "Please enter a serialized PHP string.",
+      );
+    });
+
+    it("should throw error for invalid input", () => {
+      expect(() => phpUnserialize("xyz")).toThrow();
+    });
+
+    it("should throw error for malformed string", () => {
+      expect(() => phpUnserialize("s:99:\"short\";")).toThrow();
+    });
+  });
+
+  describe("isValidSerialized", () => {
+    it("should return true for valid serialized strings", () => {
+      expect(isValidSerialized('s:5:"hello";')).toBe(true);
+      expect(isValidSerialized("i:42;")).toBe(true);
+      expect(isValidSerialized("N;")).toBe(true);
+      expect(
+        isValidSerialized(
+          'a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}',
+        ),
+      ).toBe(true);
+    });
+
+    it("should return false for invalid strings", () => {
+      expect(isValidSerialized("")).toBe(false);
+      expect(isValidSerialized("not serialized")).toBe(false);
+      expect(isValidSerialized("xyz{broken")).toBe(false);
+    });
+  });
+
+  describe("formatPrintR", () => {
+    it("should format a simple string", () => {
+      const parsed = phpUnserialize('s:5:"hello";');
+      expect(formatPrintR(parsed)).toBe("hello");
+    });
+
+    it("should format an integer", () => {
+      const parsed = phpUnserialize("i:42;");
+      expect(formatPrintR(parsed)).toBe("42");
+    });
+
+    it("should format boolean true as 1", () => {
+      const parsed = phpUnserialize("b:1;");
+      expect(formatPrintR(parsed)).toBe("1");
+    });
+
+    it("should format boolean false as empty string", () => {
+      const parsed = phpUnserialize("b:0;");
+      expect(formatPrintR(parsed)).toBe("");
+    });
+
+    it("should format null as empty string", () => {
+      const parsed = phpUnserialize("N;");
+      expect(formatPrintR(parsed)).toBe("");
+    });
+
+    it("should format a nested array matching user example", () => {
+      const input =
+        'a:2:{i:0;s:12:"Sample array";i:1;a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}}';
+      const parsed = phpUnserialize(input);
+      const result = formatPrintR(parsed);
+      const expected = [
+        "Array",
+        "(",
+        "    [0] => Sample array",
+        "    [1] => Array",
+        "        (",
+        "            [0] => Apple",
+        "            [1] => Orange",
+        "        )",
+        "",
+        ")",
+      ].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("should format an object", () => {
+      const parsed = phpUnserialize(
+        'O:8:"stdClass":1:{s:4:"name";s:5:"Alice";}',
+      );
+      const result = formatPrintR(parsed);
+      expect(result).toContain("stdClass Object");
+      expect(result).toContain("[name] => Alice");
+    });
+  });
+
+  describe("formatVarDump", () => {
+    it("should format a string with type and length", () => {
+      const parsed = phpUnserialize('s:5:"hello";');
+      expect(formatVarDump(parsed)).toBe('string(5) "hello"');
+    });
+
+    it("should format an integer with type", () => {
+      const parsed = phpUnserialize("i:42;");
+      expect(formatVarDump(parsed)).toBe("int(42)");
+    });
+
+    it("should format a float with type", () => {
+      const parsed = phpUnserialize("d:3.14;");
+      expect(formatVarDump(parsed)).toBe("float(3.14)");
+    });
+
+    it("should format boolean true", () => {
+      const parsed = phpUnserialize("b:1;");
+      expect(formatVarDump(parsed)).toBe("bool(true)");
+    });
+
+    it("should format boolean false", () => {
+      const parsed = phpUnserialize("b:0;");
+      expect(formatVarDump(parsed)).toBe("bool(false)");
+    });
+
+    it("should format null as NULL", () => {
+      const parsed = phpUnserialize("N;");
+      expect(formatVarDump(parsed)).toBe("NULL");
+    });
+
+    it("should format a nested array matching user example", () => {
+      const input =
+        'a:2:{i:0;s:12:"Sample array";i:1;a:2:{i:0;s:5:"Apple";i:1;s:6:"Orange";}}';
+      const parsed = phpUnserialize(input);
+      const result = formatVarDump(parsed);
+      const expected = [
+        "array(2) {",
+        "  [0]=>",
+        '  string(12) "Sample array"',
+        "  [1]=>",
+        "  array(2) {",
+        "    [0]=>",
+        '    string(5) "Apple"',
+        "    [1]=>",
+        '    string(6) "Orange"',
+        "  }",
+        "}",
+      ].join("\n");
+      expect(result).toBe(expected);
+    });
+
+    it("should format an object with class name", () => {
+      const parsed = phpUnserialize(
+        'O:8:"stdClass":1:{s:4:"name";s:5:"Alice";}',
+      );
+      const result = formatVarDump(parsed);
+      expect(result).toContain("object(stdClass)");
+      expect(result).toContain('["name"]=>');
+      expect(result).toContain('string(5) "Alice"');
+    });
+
+    it("should format an associative array with string keys", () => {
+      const parsed = phpUnserialize(
+        'a:2:{s:4:"name";s:5:"Alice";s:3:"age";i:30;}',
+      );
+      const result = formatVarDump(parsed);
+      expect(result).toContain('["name"]=>');
+      expect(result).toContain('string(5) "Alice"');
+      expect(result).toContain('["age"]=>');
+      expect(result).toContain("int(30)");
+    });
+  });
+});

--- a/tests/tools/php-unserializer.test.ts
+++ b/tests/tools/php-unserializer.test.ts
@@ -18,6 +18,11 @@ describe("PHP Unserialize Utils", () => {
       expect(result).toEqual({ type: "string", value: "" });
     });
 
+    it("should parse multi-byte UTF-8 strings by byte length", () => {
+      const result = phpUnserialize('s:4:"😊";');
+      expect(result).toEqual({ type: "string", value: "😊" });
+    });
+
     it("should parse an integer", () => {
       const result = phpUnserialize("i:42;");
       expect(result).toEqual({ type: "int", value: 42 });
@@ -148,6 +153,40 @@ describe("PHP Unserialize Utils", () => {
       });
     });
 
+    it("should resolve uppercase references to prior values", () => {
+      const result = phpUnserialize('a:2:{s:1:"x";s:3:"foo";s:1:"y";R:2;}');
+      expect(result).toEqual({
+        type: "array",
+        entries: [
+          {
+            key: { type: "string", value: "x" },
+            value: { type: "string", value: "foo" },
+          },
+          {
+            key: { type: "string", value: "y" },
+            value: { type: "string", value: "foo" },
+          },
+        ],
+      });
+    });
+
+    it("should resolve lowercase references to prior values", () => {
+      const result = phpUnserialize('a:2:{s:1:"x";s:3:"foo";s:1:"y";r:2;}');
+      expect(result).toEqual({
+        type: "array",
+        entries: [
+          {
+            key: { type: "string", value: "x" },
+            value: { type: "string", value: "foo" },
+          },
+          {
+            key: { type: "string", value: "y" },
+            value: { type: "string", value: "foo" },
+          },
+        ],
+      });
+    });
+
     it("should throw error for empty input", () => {
       expect(() => phpUnserialize("")).toThrow(
         "Please enter a serialized PHP string.",
@@ -163,6 +202,12 @@ describe("PHP Unserialize Utils", () => {
 
     it("should throw error for malformed string", () => {
       expect(() => phpUnserialize("s:99:\"short\";")).toThrow();
+    });
+
+    it("should throw error for invalid reference index", () => {
+      expect(() =>
+        phpUnserialize('a:1:{s:1:"x";R:99;}'),
+      ).toThrow("Reference index 99 does not exist");
     });
   });
 
@@ -247,6 +292,11 @@ describe("PHP Unserialize Utils", () => {
       expect(formatVarDump(parsed)).toBe('string(5) "hello"');
     });
 
+    it("should format UTF-8 string length in bytes", () => {
+      const parsed = phpUnserialize('s:4:"😊";');
+      expect(formatVarDump(parsed)).toBe('string(4) "😊"');
+    });
+
     it("should format an integer with type", () => {
       const parsed = phpUnserialize("i:42;");
       expect(formatVarDump(parsed)).toBe("int(42)");
@@ -312,6 +362,36 @@ describe("PHP Unserialize Utils", () => {
       expect(result).toContain('string(5) "Alice"');
       expect(result).toContain('["age"]=>');
       expect(result).toContain("int(30)");
+    });
+
+    it("should normalize non-standard key value types consistently", () => {
+      const parsed = {
+        type: "array",
+        entries: [
+          {
+            key: { type: "bool", value: true },
+            value: { type: "string", value: "one" },
+          },
+          {
+            key: { type: "null" },
+            value: { type: "string", value: "empty" },
+          },
+          {
+            key: { type: "float", value: 3.9 },
+            value: { type: "string", value: "three" },
+          },
+        ],
+      } as const;
+
+      const printR = formatPrintR(parsed);
+      expect(printR).toContain("[1] => one");
+      expect(printR).toContain("[] => empty");
+      expect(printR).toContain("[3] => three");
+
+      const varDump = formatVarDump(parsed);
+      expect(varDump).toContain("[\"1\"]=>");
+      expect(varDump).toContain("[\"\"]=>");
+      expect(varDump).toContain("[\"3\"]=>");
     });
   });
 });


### PR DESCRIPTION
This PR introduces a new PHP Unserializer tool in DevTools to help format raw PHP serialized strings into readable output.

As a WordPress plugin developer, I frequently need to inspect serialized values stored in the WordPress database (options, post meta, user meta, transients, etc.). Most of the WP devs use online tool to unserialize, so this tool is added to speed up day-to-day debugging and development.

### Why this is useful
- Common WordPress workflow improvement for plugin/theme developers
- Faster debugging of DB-stored serialized payloads
- Reduces mistakes compared to manual inspection/conversion or use another tool.

### Test plan
- Verified sample serialized input renders correctly in both formats
- Added utility tests for parser and formatters (including nested cases and error handling)
- Ran full test suite to confirm no regressions