### PR TITLE
feat: add JSON Diff Viewer tool

### DIFF
--- a/src/app/toolRegistry.ts
+++ b/src/app/toolRegistry.ts
@@ -10,6 +10,7 @@ import {
   FileJson,
   FileText,
   Globe,
+  GitCompare,
   Hash,
   Image as ImageIcon,
   Key,
@@ -32,6 +33,7 @@ const lazyNamed = <T extends Record<string, ComponentType>>(
 
 export const ALL_TOOLS = [
   { icon: FileJson, name: "JSON Viewer", id: "json-viewer", category: "Development Tools" },
+  { icon: GitCompare, name: "JSON Diff Viewer", id: "json-diff-viewer", category: "Development Tools" },
   { icon: Code, name: "Code Playground", id: "code-playground", category: "Development Tools" },
   { icon: Terminal, name: "Regex Generator", id: "regex-generator", category: "Development Tools" },
   { icon: Type, name: "JSON to TypeScript", id: "json-typescript", category: "Development Tools" },
@@ -70,6 +72,7 @@ export const TOOL_BY_ID = new Map<ToolId, ToolDefinition>(ALL_TOOLS.map((tool) =
 
 export const TOOL_COMPONENTS: Record<ToolId, LazyExoticComponent<ComponentType>> = {
   "json-viewer": lazyNamed(() => import("@/components/tools/JsonViewer"), "JsonViewer"),
+  "json-diff-viewer": lazyNamed(() => import("@/components/tools/JsonDiffViewer"), "JsonDiffViewer"),
   "code-playground": lazyNamed(() => import("@/components/tools/CodePlayground"), "CodePlayground"),
   "regex-generator": lazyNamed(() => import("@/components/tools/RegexGenerator"), "RegexGenerator"),
   "json-typescript": lazyNamed(() => import("@/components/tools/JsonToTypeScript"), "JsonToTypeScript"),

--- a/src/components/tools/JsonDiffViewer.tsx
+++ b/src/components/tools/JsonDiffViewer.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { diffJsonValues, formatDiffValue, type JsonDiffEntry } from "@/utils/json-diff";
+import { diffJsonValues, formatDiffValue, MAX_DIFF_ENTRIES, type JsonDiffEntry, } from "@/utils/json-diff";
 
 const SAMPLE_ORIGINAL = JSON.stringify(
   {
@@ -103,21 +103,25 @@ export function JsonDiffViewer() {
       return;
     }
 
-    let parsedOriginal: unknown;
-    let parsedModified: unknown;
+    let parsedOriginal: unknown = null;
+    let parsedModified: unknown = null;
     let validationFailed = false;
 
     try {
-      parsedOriginal = JSON.parse(originalInput);
-      setOriginalInput(JSON.stringify(parsedOriginal, null, 2));
+      if (originalInput.trim()) {
+        parsedOriginal = JSON.parse(originalInput);
+        setOriginalInput(JSON.stringify(parsedOriginal, null, 2));
+      }
     } catch (error) {
       setOriginalError(`Invalid JSON: ${getErrorMessage(error)}`);
       validationFailed = true;
     }
 
     try {
-      parsedModified = JSON.parse(modifiedInput);
-      setModifiedInput(JSON.stringify(parsedModified, null, 2));
+      if (modifiedInput.trim()) {
+        parsedModified = JSON.parse(modifiedInput);
+        setModifiedInput(JSON.stringify(parsedModified, null, 2));
+      }
     } catch (error) {
       setModifiedError(`Invalid JSON: ${getErrorMessage(error)}`);
       validationFailed = true;
@@ -134,7 +138,7 @@ export function JsonDiffViewer() {
       setTimeout(() => {
         const result = diffJsonValues(parsedOriginal, parsedModified, {
           includeUnchanged: true,
-          maxEntries: 10000,
+          maxEntries: MAX_DIFF_ENTRIES,
         });
 
         setEntries(result.entries);
@@ -315,7 +319,7 @@ export function JsonDiffViewer() {
 
             {truncated && (
               <p className="text-sm text-muted-foreground">
-                Result limit reached. Showing the first 10,000 entries.
+                Result limit reached. Showing the first {MAX_DIFF_ENTRIES.toLocaleString()} entries.
               </p>
             )}
           </CardHeader>

--- a/src/components/tools/JsonDiffViewer.tsx
+++ b/src/components/tools/JsonDiffViewer.tsx
@@ -1,0 +1,376 @@
+import { useMemo, useState, useTransition } from "react";
+import { ArrowLeftRight, Check, Copy, Eraser, GitCompare, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { diffJsonValues, formatDiffValue, type JsonDiffEntry } from "@/utils/json-diff";
+
+const SAMPLE_ORIGINAL = JSON.stringify(
+  {
+    name: "DevTools Desktop",
+    version: "1.3.0",
+    features: ["json-viewer", "jwt-decoder", "text-compare"],
+    settings: {
+      theme: "dark",
+      autoUpdate: true,
+      shortcuts: {
+        commandPalette: "Ctrl+K",
+        sidebarToggle: "Ctrl+B",
+      },
+    },
+  },
+  null,
+  2,
+);
+
+const SAMPLE_MODIFIED = JSON.stringify(
+  {
+    name: "DevTools Desktop",
+    version: "1.4.0",
+    features: ["json-viewer", "jwt-decoder", "text-compare", "json-diff-viewer"],
+    settings: {
+      theme: "system",
+      autoUpdate: false,
+      shortcuts: {
+        commandPalette: "Ctrl+Shift+P",
+      },
+    },
+    metadata: {
+      releaseDate: "2026-03-30",
+    },
+  },
+  null,
+  2,
+);
+
+const ENTRY_CLASSES: Record<JsonDiffEntry["type"], string> = {
+  added: "border-green-500/30 bg-green-500/10",
+  removed: "border-red-500/30 bg-red-500/10",
+  changed: "border-yellow-500/30 bg-yellow-500/10",
+  unchanged: "border-border bg-muted/40",
+};
+
+const BADGE_CLASSES: Record<JsonDiffEntry["type"], string> = {
+  added: "bg-green-500 text-white",
+  removed: "bg-red-500 text-white",
+  changed: "bg-yellow-500 text-black",
+  unchanged: "border border-border bg-background text-foreground",
+};
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Invalid JSON";
+}
+
+export function JsonDiffViewer() {
+  const [originalInput, setOriginalInput] = useState("");
+  const [modifiedInput, setModifiedInput] = useState("");
+  const [originalError, setOriginalError] = useState("");
+  const [modifiedError, setModifiedError] = useState("");
+  const [entries, setEntries] = useState<JsonDiffEntry[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const [showOnlyDifferences, setShowOnlyDifferences] = useState(true);
+  const [hasCompared, setHasCompared] = useState(false);
+  const [copiedField, setCopiedField] = useState<"original" | "modified" | null>(null);
+  const [isComparing, startTransition] = useTransition();
+
+  const filteredEntries = useMemo(() => {
+    if (!showOnlyDifferences) {
+      return entries;
+    }
+
+    return entries.filter((entry) => entry.type !== "unchanged");
+  }, [entries, showOnlyDifferences]);
+
+  const counts = useMemo(() => {
+    return entries.reduce(
+      (accumulator, entry) => {
+        accumulator[entry.type] += 1;
+        return accumulator;
+      },
+      { added: 0, removed: 0, changed: 0, unchanged: 0 },
+    );
+  }, [entries]);
+
+  const compareJson = () => {
+    setOriginalError("");
+    setModifiedError("");
+
+    if (!originalInput.trim() && !modifiedInput.trim()) {
+      toast.error("Enter JSON in at least one panel.");
+      return;
+    }
+
+    let parsedOriginal: unknown;
+    let parsedModified: unknown;
+    let validationFailed = false;
+
+    try {
+      parsedOriginal = JSON.parse(originalInput);
+      setOriginalInput(JSON.stringify(parsedOriginal, null, 2));
+    } catch (error) {
+      setOriginalError(`Invalid JSON: ${getErrorMessage(error)}`);
+      validationFailed = true;
+    }
+
+    try {
+      parsedModified = JSON.parse(modifiedInput);
+      setModifiedInput(JSON.stringify(parsedModified, null, 2));
+    } catch (error) {
+      setModifiedError(`Invalid JSON: ${getErrorMessage(error)}`);
+      validationFailed = true;
+    }
+
+    if (validationFailed) {
+      setEntries([]);
+      setTruncated(false);
+      setHasCompared(false);
+      return;
+    }
+
+    startTransition(() => {
+      setTimeout(() => {
+        const result = diffJsonValues(parsedOriginal, parsedModified, {
+          includeUnchanged: true,
+          maxEntries: 10000,
+        });
+
+        setEntries(result.entries);
+        setTruncated(result.truncated);
+        setHasCompared(true);
+        toast.success("Comparison complete.");
+      }, 0);
+    });
+  };
+
+  const copyText = async (value: string, field: "original" | "modified") => {
+    if (!value.trim()) {
+      toast.error("Nothing to copy.");
+      return;
+    }
+
+    await navigator.clipboard.writeText(value);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 1200);
+    toast.success("Copied to clipboard.");
+  };
+
+  const loadSample = () => {
+    setOriginalInput(SAMPLE_ORIGINAL);
+    setModifiedInput(SAMPLE_MODIFIED);
+    setOriginalError("");
+    setModifiedError("");
+    setEntries([]);
+    setHasCompared(false);
+    setTruncated(false);
+  };
+
+  const swapJson = () => {
+    setOriginalInput(modifiedInput);
+    setModifiedInput(originalInput);
+    setOriginalError(modifiedError);
+    setModifiedError(originalError);
+    setEntries([]);
+    setHasCompared(false);
+    setTruncated(false);
+  };
+
+  const clearAll = () => {
+    setOriginalInput("");
+    setModifiedInput("");
+    setOriginalError("");
+    setModifiedError("");
+    setEntries([]);
+    setTruncated(false);
+    setHasCompared(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={compareJson} className="gap-2" disabled={isComparing}>
+          <GitCompare className="h-4 w-4" />
+          {isComparing ? "Comparing..." : "Compare"}
+        </Button>
+        <Button variant="outline" onClick={loadSample} className="gap-2">
+          <Sparkles className="h-4 w-4" />
+          Sample JSON
+        </Button>
+        <Button variant="outline" onClick={swapJson} className="gap-2">
+          <ArrowLeftRight className="h-4 w-4" />
+          Swap JSON
+        </Button>
+        <Button variant="outline" onClick={clearAll} className="gap-2">
+          <Eraser className="h-4 w-4" />
+          Clear
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <CardTitle>Original JSON</CardTitle>
+                <CardDescription>Source JSON object</CardDescription>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => copyText(originalInput, "original")}
+                className="gap-2"
+              >
+                {copiedField === "original" ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                {copiedField === "original" ? "Copied" : "Copy"}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Textarea
+              value={originalInput}
+              onChange={(event) => setOriginalInput(event.target.value)}
+              placeholder='{"name": "example"}'
+              className="min-h-[280px] font-mono"
+            />
+            {originalError && (
+              <p className="text-sm text-destructive" role="alert">
+                {originalError}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <CardTitle>Modified JSON</CardTitle>
+                <CardDescription>Updated JSON object</CardDescription>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => copyText(modifiedInput, "modified")}
+                className="gap-2"
+              >
+                {copiedField === "modified" ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                {copiedField === "modified" ? "Copied" : "Copy"}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Textarea
+              value={modifiedInput}
+              onChange={(event) => setModifiedInput(event.target.value)}
+              placeholder='{"name": "example", "enabled": true}'
+              className="min-h-[280px] font-mono"
+            />
+            {modifiedError && (
+              <p className="text-sm text-destructive" role="alert">
+                {modifiedError}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {hasCompared && (
+        <Card>
+          <CardHeader className="space-y-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle>Diff Results</CardTitle>
+                <CardDescription>Human-readable JSON comparison by path</CardDescription>
+              </div>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="show-only-differences">Show only differences</Label>
+                <Switch
+                  id="show-only-differences"
+                  checked={showOnlyDifferences}
+                  onCheckedChange={setShowOnlyDifferences}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+              <div className="rounded border border-green-500/30 bg-green-500/10 p-2 text-center text-sm">
+                <p className="text-lg font-semibold text-green-600 dark:text-green-400">{counts.added}</p>
+                <p className="text-muted-foreground">Added</p>
+              </div>
+              <div className="rounded border border-red-500/30 bg-red-500/10 p-2 text-center text-sm">
+                <p className="text-lg font-semibold text-red-600 dark:text-red-400">{counts.removed}</p>
+                <p className="text-muted-foreground">Removed</p>
+              </div>
+              <div className="rounded border border-yellow-500/30 bg-yellow-500/10 p-2 text-center text-sm">
+                <p className="text-lg font-semibold text-yellow-600 dark:text-yellow-400">{counts.changed}</p>
+                <p className="text-muted-foreground">Changed</p>
+              </div>
+              <div className="rounded border bg-muted p-2 text-center text-sm">
+                <p className="text-lg font-semibold">{counts.unchanged}</p>
+                <p className="text-muted-foreground">Unchanged</p>
+              </div>
+            </div>
+
+            {truncated && (
+              <p className="text-sm text-muted-foreground">
+                Result limit reached. Showing the first 10,000 entries.
+              </p>
+            )}
+          </CardHeader>
+
+          <CardContent>
+            {filteredEntries.length === 0 ? (
+              <div className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+                No entries to display for the current filter.
+              </div>
+            ) : (
+              <div className="max-h-[560px] space-y-3 overflow-auto pr-1">
+                {filteredEntries.map((entry) => (
+                  <div key={`${entry.path}:${entry.type}`} className={`rounded-md border p-3 ${ENTRY_CLASSES[entry.type]}`}>
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <span className={`rounded px-2 py-0.5 text-xs font-medium ${BADGE_CLASSES[entry.type]}`}>
+                        {entry.type.toUpperCase()}
+                      </span>
+                      <code className="rounded bg-background/70 px-2 py-0.5 text-xs">{entry.path}</code>
+                    </div>
+
+                    {entry.type === "added" && (
+                      <pre className="overflow-x-auto rounded bg-background/70 p-2 text-xs">
+                        <code>{formatDiffValue(entry.modified)}</code>
+                      </pre>
+                    )}
+
+                    {entry.type === "removed" && (
+                      <pre className="overflow-x-auto rounded bg-background/70 p-2 text-xs">
+                        <code>{formatDiffValue(entry.original)}</code>
+                      </pre>
+                    )}
+
+                    {entry.type === "changed" && (
+                      <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+                        <div>
+                          <p className="mb-1 text-xs font-medium text-muted-foreground">Original</p>
+                          <pre className="overflow-x-auto rounded bg-background/70 p-2 text-xs">
+                            <code>{formatDiffValue(entry.original)}</code>
+                          </pre>
+                        </div>
+                        <div>
+                          <p className="mb-1 text-xs font-medium text-muted-foreground">Modified</p>
+                          <pre className="overflow-x-auto rounded bg-background/70 p-2 text-xs">
+                            <code>{formatDiffValue(entry.modified)}</code>
+                          </pre>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/utils/json-diff.ts
+++ b/src/utils/json-diff.ts
@@ -17,6 +17,8 @@ export interface JsonDiffOptions {
   maxEntries?: number;
 }
 
+export const MAX_DIFF_ENTRIES = 10000;
+
 const IDENTIFIER_REGEX = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
 function isObjectLike(value: unknown): value is Record<string, unknown> {
@@ -29,7 +31,7 @@ function formatObjectKey(key: string): string {
 
 function appendPath(parent: string, segment: string): string {
   if (parent === "$") {
-    return segment.startsWith("[") ? `$${segment}` : `$${segment}`;
+    return `$${segment}`;
   }
 
   return `${parent}${segment}`;
@@ -41,7 +43,7 @@ export function diffJsonValues(
   options: JsonDiffOptions = {},
 ): JsonDiffResult {
   const includeUnchanged = options.includeUnchanged ?? true;
-  const maxEntries = options.maxEntries ?? 5000;
+  const maxEntries = options.maxEntries ?? MAX_DIFF_ENTRIES;
   const entries: JsonDiffEntry[] = [];
   let truncated = false;
 

--- a/src/utils/json-diff.ts
+++ b/src/utils/json-diff.ts
@@ -1,0 +1,138 @@
+export type JsonDiffType = "added" | "removed" | "changed" | "unchanged";
+
+export interface JsonDiffEntry {
+  path: string;
+  type: JsonDiffType;
+  original?: unknown;
+  modified?: unknown;
+}
+
+export interface JsonDiffResult {
+  entries: JsonDiffEntry[];
+  truncated: boolean;
+}
+
+export interface JsonDiffOptions {
+  includeUnchanged?: boolean;
+  maxEntries?: number;
+}
+
+const IDENTIFIER_REGEX = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatObjectKey(key: string): string {
+  return IDENTIFIER_REGEX.test(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
+}
+
+function appendPath(parent: string, segment: string): string {
+  if (parent === "$") {
+    return segment.startsWith("[") ? `$${segment}` : `$${segment}`;
+  }
+
+  return `${parent}${segment}`;
+}
+
+export function diffJsonValues(
+  original: unknown,
+  modified: unknown,
+  options: JsonDiffOptions = {},
+): JsonDiffResult {
+  const includeUnchanged = options.includeUnchanged ?? true;
+  const maxEntries = options.maxEntries ?? 5000;
+  const entries: JsonDiffEntry[] = [];
+  let truncated = false;
+
+  const pushEntry = (entry: JsonDiffEntry) => {
+    if (truncated) {
+      return;
+    }
+
+    if (entries.length >= maxEntries) {
+      truncated = true;
+      return;
+    }
+
+    entries.push(entry);
+  };
+
+  const compare = (path: string, left: unknown, right: unknown) => {
+    if (truncated) {
+      return;
+    }
+
+    if (Object.is(left, right)) {
+      if (includeUnchanged) {
+        pushEntry({ path, type: "unchanged", original: left, modified: right });
+      }
+      return;
+    }
+
+    if (Array.isArray(left) && Array.isArray(right)) {
+      const maxLength = Math.max(left.length, right.length);
+
+      for (let index = 0; index < maxLength; index += 1) {
+        const childPath = appendPath(path, `[${index}]`);
+
+        if (index >= left.length) {
+          pushEntry({ path: childPath, type: "added", modified: right[index] });
+          continue;
+        }
+
+        if (index >= right.length) {
+          pushEntry({ path: childPath, type: "removed", original: left[index] });
+          continue;
+        }
+
+        compare(childPath, left[index], right[index]);
+      }
+
+      return;
+    }
+
+    if (isObjectLike(left) && isObjectLike(right)) {
+      const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+      const sortedKeys = [...keys].sort((a, b) => a.localeCompare(b));
+
+      for (const key of sortedKeys) {
+        const childPath = appendPath(path, formatObjectKey(key));
+        const hasLeft = Object.prototype.hasOwnProperty.call(left, key);
+        const hasRight = Object.prototype.hasOwnProperty.call(right, key);
+
+        if (!hasLeft && hasRight) {
+          pushEntry({ path: childPath, type: "added", modified: right[key] });
+          continue;
+        }
+
+        if (hasLeft && !hasRight) {
+          pushEntry({ path: childPath, type: "removed", original: left[key] });
+          continue;
+        }
+
+        compare(childPath, left[key], right[key]);
+      }
+
+      return;
+    }
+
+    pushEntry({ path, type: "changed", original: left, modified: right });
+  };
+
+  compare("$", original, modified);
+
+  return { entries, truncated };
+}
+
+export function formatDiffValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  return JSON.stringify(value, null, 2);
+}

--- a/tests/tools/json-diff.test.ts
+++ b/tests/tools/json-diff.test.ts
@@ -36,6 +36,50 @@ describe("JSON Diff Utils", () => {
     expect(result.entries.some((entry) => entry.path === "$.items[2]" && entry.type === "removed")).toBe(true);
   });
 
+  it("detects root-level primitive changes", () => {
+    const result = diffJsonValues("1.0.0", "1.1.0", { includeUnchanged: false });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      path: "$",
+      type: "changed",
+      original: "1.0.0",
+      modified: "1.1.0",
+    });
+  });
+
+  it("adds and removes array elements", () => {
+    const result = diffJsonValues(
+      { items: ["a"] },
+      { items: ["a", "b", "c"] },
+      { includeUnchanged: false },
+    );
+
+    expect(result.entries.some((entry) => entry.path === "$.items[1]" && entry.type === "added")).toBe(true);
+    expect(result.entries.some((entry) => entry.path === "$.items[2]" && entry.type === "added")).toBe(true);
+  });
+
+  it("uses bracket path format for non-identifier keys", () => {
+    const result = diffJsonValues(
+      { "display-name": "Alice" },
+      { "display-name": "Bob" },
+      { includeUnchanged: false },
+    );
+
+    expect(result.entries.some((entry) => entry.path === '$["display-name"]' && entry.type === "changed")).toBe(true);
+  });
+
+  it("includes unchanged entries when enabled", () => {
+    const result = diffJsonValues(
+      { a: 1, b: 2 },
+      { a: 1, b: 3 },
+      { includeUnchanged: true },
+    );
+
+    expect(result.entries.some((entry) => entry.path === "$.a" && entry.type === "unchanged")).toBe(true);
+    expect(result.entries.some((entry) => entry.path === "$.b" && entry.type === "changed")).toBe(true);
+  });
+
   it("filters unchanged when requested", () => {
     const result = diffJsonValues(
       { a: 1, b: 2 },
@@ -47,6 +91,33 @@ describe("JSON Diff Utils", () => {
     expect(result.entries.some((entry) => entry.path === "$.b" && entry.type === "changed")).toBe(true);
   });
 
+  it("returns no entries for identical values when unchanged is disabled", () => {
+    const result = diffJsonValues({ a: 1 }, { a: 1 }, { includeUnchanged: false });
+
+    expect(result.entries).toHaveLength(0);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("treats NaN values as unchanged", () => {
+    const result = diffJsonValues({ value: Number.NaN }, { value: Number.NaN }, { includeUnchanged: true });
+
+    expect(result.entries.some((entry) => entry.path === "$.value" && entry.type === "unchanged")).toBe(true);
+  });
+
+  it("handles type changes between object and primitive", () => {
+    const result = diffJsonValues(
+      { data: { nested: true } },
+      { data: "replaced" },
+      { includeUnchanged: false },
+    );
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      path: "$.data",
+      type: "changed",
+    });
+  });
+
   it("truncates result when max entries is reached", () => {
     const original = { a: 1, b: 2, c: 3 };
     const modified = { a: 2, b: 3, c: 4 };
@@ -56,9 +127,21 @@ describe("JSON Diff Utils", () => {
     expect(result.entries).toHaveLength(2);
   });
 
+  it("does not truncate when entry count stays within limit", () => {
+    const result = diffJsonValues(
+      { a: 1, b: 2 },
+      { a: 2, b: 3 },
+      { maxEntries: 3, includeUnchanged: false },
+    );
+
+    expect(result.truncated).toBe(false);
+    expect(result.entries).toHaveLength(2);
+  });
+
   it("formats diff values for display", () => {
     expect(formatDiffValue("hello")).toBe("hello");
     expect(formatDiffValue(undefined)).toBe("undefined");
     expect(formatDiffValue({ a: 1 })).toContain('"a": 1');
+    expect(formatDiffValue([1, 2])).toContain("[\n");
   });
 });

--- a/tests/tools/json-diff.test.ts
+++ b/tests/tools/json-diff.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { diffJsonValues, formatDiffValue } from "@/utils/json-diff";
+
+describe("JSON Diff Utils", () => {
+  it("detects changed, added, and removed entries", () => {
+    const original = {
+      name: "DevTools",
+      version: "1.0.0",
+      enabled: true,
+      nested: { a: 1 },
+    };
+
+    const modified = {
+      name: "DevTools",
+      version: "1.1.0",
+      nested: { a: 2 },
+      newKey: "new",
+    };
+
+    const result = diffJsonValues(original, modified, { includeUnchanged: true });
+
+    expect(result.entries.some((entry) => entry.path === "$.version" && entry.type === "changed")).toBe(true);
+    expect(result.entries.some((entry) => entry.path === "$.enabled" && entry.type === "removed")).toBe(true);
+    expect(result.entries.some((entry) => entry.path === "$.newKey" && entry.type === "added")).toBe(true);
+    expect(result.entries.some((entry) => entry.path === "$.nested.a" && entry.type === "changed")).toBe(true);
+  });
+
+  it("supports array paths", () => {
+    const result = diffJsonValues(
+      { items: [1, 2, 3] },
+      { items: [1, 4] },
+      { includeUnchanged: true },
+    );
+
+    expect(result.entries.some((entry) => entry.path === "$.items[1]" && entry.type === "changed")).toBe(true);
+    expect(result.entries.some((entry) => entry.path === "$.items[2]" && entry.type === "removed")).toBe(true);
+  });
+
+  it("filters unchanged when requested", () => {
+    const result = diffJsonValues(
+      { a: 1, b: 2 },
+      { a: 1, b: 3 },
+      { includeUnchanged: false },
+    );
+
+    expect(result.entries.some((entry) => entry.type === "unchanged")).toBe(false);
+    expect(result.entries.some((entry) => entry.path === "$.b" && entry.type === "changed")).toBe(true);
+  });
+
+  it("truncates result when max entries is reached", () => {
+    const original = { a: 1, b: 2, c: 3 };
+    const modified = { a: 2, b: 3, c: 4 };
+    const result = diffJsonValues(original, modified, { maxEntries: 2, includeUnchanged: false });
+
+    expect(result.truncated).toBe(true);
+    expect(result.entries).toHaveLength(2);
+  });
+
+  it("formats diff values for display", () => {
+    expect(formatDiffValue("hello")).toBe("hello");
+    expect(formatDiffValue(undefined)).toBe("undefined");
+    expect(formatDiffValue({ a: 1 })).toContain('"a": 1');
+  });
+});


### PR DESCRIPTION
This PR features a new JSON Diff Viewer tool that enables users to compare two JSON objects (Original vs. Modified) and see differences in a clear, human-readable format.

Included:
- New JSON Diff Viewer tool
- JSON validation and error display
- Compare action with easy-to-readable diff output (added/removed/changed)
- Copy buttons, sample JSON, swap, etc.

<img width="1919" height="916" alt="2" src="https://github.com/user-attachments/assets/2a17ae41-2f75-4277-9913-2d9fccf085fe" />

